### PR TITLE
Fetch issue labels by IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ repository, the first page of open issues is also queried at the same time.
 Then, all repositories that still have more open issues are queried repeatedly
 in batches to get their remaining pages of open issues.
 
-The key difference from `orgs-then-issues` is that this command fetches a page
-of issues for each repository as part of the same requests that fetch the
-repositories themselves.
+When querying issues, the first 10 (by default) labels are retrieved for each
+issue.  If any issue has more than this many labels, the remaining labels are
+queried in batches at this point.
+
+The key difference from `orgs-then-issues` is that this command fetches an
+initial page of issues for each repository as part of the same requests that
+fetch the repositories themselves.
 
 The program logs to stderr the number of repositories fetched, the number of
 open issues fetched, the elapsed time, and (if possible) the number of API rate
@@ -64,6 +68,9 @@ limit points used.
 
 - `-B <int>`/`--batch-size <int>` — Set the number of sub-queries to make per
   GraphQL request [default: 50]
+
+- `-L <int>`/`--label-page-size <int>` — Set the number of labels to request
+  per page [default: 10]
 
 - `-o <path>`/`--outfile <path>` — Dump fetched issue information to the given
   file as JSON Lines.  `<path>` may be `-` to write to standard output.

--- a/crates/orgs-with-issues/src/main.rs
+++ b/crates/orgs-with-issues/src/main.rs
@@ -1,11 +1,13 @@
 mod queries;
 mod types;
 use crate::queries::{GetIssues, GetOwnerRepos};
+use crate::types::Issue;
 use anyhow::Context;
 use clap::Parser;
-use gqlient::{Client, Ided, DEFAULT_BATCH_SIZE};
+use gqlient::{Client, Id, Ided, DEFAULT_BATCH_SIZE};
 use serde::Serialize;
 use serde_jsonlines::{append_json_lines, WriteExt};
+use std::collections::HashMap;
 use std::io::Write;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -17,6 +19,10 @@ struct Arguments {
     /// Number of sub-queries to make per GraphQL request
     #[arg(short = 'B', long)]
     batch_size: Option<NonZeroUsize>,
+
+    /// Number of labels to request per page
+    #[arg(short = 'L', long, default_value = "10")]
+    label_page_size: NonZeroUsize,
 
     /// Dump fetched issue information to the given file
     #[arg(short, long)]
@@ -47,29 +53,34 @@ fn main() -> anyhow::Result<()> {
     let timestamp = SystemTime::now();
     let mut repo_qty = 0;
     let mut repos_with_issues_qty: usize = 0;
-    let mut issues = Vec::new();
+    let mut issues = HashMap::<Id, Issue>::new();
 
     eprintln!("[·] Fetching repositories …");
-    let owner_queries = args
-        .owners
-        .clone()
-        .into_iter()
-        .map(|owner| (owner.clone(), GetOwnerRepos::new(owner, args.page_size)));
+    let owner_queries = args.owners.clone().into_iter().map(|owner| {
+        (
+            owner.clone(),
+            GetOwnerRepos::new(owner, args.page_size, args.label_page_size),
+        )
+    });
     let repos_start = Instant::now();
     let repos = client.batch_paginate(owner_queries)?;
     let elapsed = repos_start.elapsed();
 
     let mut issue_queries = Vec::new();
+    let mut label_queries = Vec::new();
     for Ided { id, data: repo } in repos.into_iter().flat_map(|pr| pr.items) {
         repo_qty += 1;
         if !repo.issues.is_empty() {
             repos_with_issues_qty += 1;
-            issues.extend(repo.issues);
+            for iwl in repo.issues {
+                label_queries.extend(iwl.more_labels_query(args.label_page_size));
+                issues.insert(iwl.issue_id, iwl.issue);
+            }
         }
         if repo.has_more_issues {
             issue_queries.push((
                 id.clone(),
-                GetIssues::new(id, repo.issue_cursor, args.page_size),
+                GetIssues::new(id, repo.issue_cursor, args.page_size, args.label_page_size),
             ));
         }
     }
@@ -90,13 +101,30 @@ fn main() -> anyhow::Result<()> {
         let more_issues = client.batch_paginate(issue_queries)?;
         let elapsed = start.elapsed();
         let mut issue_qty = 0;
-        issues.extend(
-            more_issues
-                .into_iter()
-                .flat_map(|pr| pr.items)
-                .inspect(|_| issue_qty += 1),
-        );
+        for iwl in more_issues.into_iter().flat_map(|pr| pr.items) {
+            label_queries.extend(iwl.more_labels_query(args.label_page_size));
+            issue_qty += 1;
+            issues.insert(iwl.issue_id, iwl.issue);
+        }
         eprintln!("[·] Fetched {issue_qty} more issues in {elapsed:?}");
+    }
+
+    let issues_with_extra_labels = label_queries.len();
+    if !label_queries.is_empty() {
+        eprintln!("[·] Fetching more labels for {issues_with_extra_labels} issues …",);
+        let start = Instant::now();
+        let more_labels = client.batch_paginate(label_queries)?;
+        let elapsed = start.elapsed();
+        let mut label_qty = 0;
+        for res in more_labels {
+            label_qty += res.items.len();
+            issues
+                .get_mut(&res.key)
+                .expect("Issues we get labels for should have already been seen")
+                .labels
+                .extend(res.items);
+        }
+        eprintln!("[·] Fetched {label_qty} more labels in {elapsed:?}");
     }
 
     let elapsed = big_start.elapsed();
@@ -127,10 +155,12 @@ fn main() -> anyhow::Result<()> {
                     None => DEFAULT_BATCH_SIZE,
                 },
                 page_size: args.page_size,
+                label_page_size: args.label_page_size,
             },
             repositories: repo_qty,
             open_issues: issues.len(),
             repos_with_open_issues: repos_with_issues_qty,
+            issues_with_extra_labels,
             elapsed,
             rate_limit_points,
         };
@@ -141,7 +171,7 @@ fn main() -> anyhow::Result<()> {
     if let Some(outfile) = args.outfile {
         eprintln!("[·] Dumping to {outfile:#} …");
         let mut fp = outfile.create().context("failed to open file")?;
-        fp.write_json_lines(issues)
+        fp.write_json_lines(issues.values())
             .context("failed to dump issues")?;
         fp.flush().context("failed to flush filehandle")?;
     }
@@ -159,6 +189,7 @@ struct Report {
     repositories: usize,
     open_issues: usize,
     repos_with_open_issues: usize,
+    issues_with_extra_labels: usize,
     elapsed: Duration,
     rate_limit_points: Option<u32>,
 }
@@ -167,4 +198,5 @@ struct Report {
 struct Parameters {
     batch_size: usize,
     page_size: NonZeroUsize,
+    label_page_size: NonZeroUsize,
 }

--- a/crates/orgs-with-issues/src/queries/get_issues.rs
+++ b/crates/orgs-with-issues/src/queries/get_issues.rs
@@ -113,7 +113,7 @@ impl Query for GetIssuesQuery {
                             url
                             labels (first: {label_page_size}) {{
                                 nodes {{
-                                    name
+                                    id
                                 }}
                                 pageInfo {{
                                     endCursor

--- a/crates/orgs-with-issues/src/queries/get_issues.rs
+++ b/crates/orgs-with-issues/src/queries/get_issues.rs
@@ -1,4 +1,4 @@
-use crate::types::{Issue, RepoWithIssues};
+use crate::types::{IssueWithLabels, RepoWithIssues};
 use gqlient::{Cursor, Id, Page, Paginator, Query, Variable};
 use indoc::indoc;
 use std::fmt::{self, Write};
@@ -9,20 +9,27 @@ pub(crate) struct GetIssues {
     repo_id: Id,
     cursor: Option<Cursor>,
     page_size: NonZeroUsize,
+    label_page_size: NonZeroUsize,
 }
 
 impl GetIssues {
-    pub(crate) fn new(repo_id: Id, cursor: Option<Cursor>, page_size: NonZeroUsize) -> GetIssues {
+    pub(crate) fn new(
+        repo_id: Id,
+        cursor: Option<Cursor>,
+        page_size: NonZeroUsize,
+        label_page_size: NonZeroUsize,
+    ) -> GetIssues {
         GetIssues {
             repo_id,
             cursor,
             page_size,
+            label_page_size,
         }
     }
 }
 
 impl Paginator for GetIssues {
-    type Item = Issue;
+    type Item = IssueWithLabels;
     type Query = GetIssuesQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetIssuesQuery {
@@ -33,6 +40,7 @@ impl Paginator for GetIssues {
                 None => self.cursor.clone(),
             },
             self.page_size,
+            self.label_page_size,
         )
     }
 }
@@ -42,15 +50,22 @@ pub(crate) struct GetIssuesQuery {
     repo_id: Id,
     cursor: Option<Cursor>,
     page_size: NonZeroUsize,
+    label_page_size: NonZeroUsize,
     prefix: Option<String>,
 }
 
 impl GetIssuesQuery {
-    fn new(repo_id: Id, cursor: Option<Cursor>, page_size: NonZeroUsize) -> GetIssuesQuery {
+    fn new(
+        repo_id: Id,
+        cursor: Option<Cursor>,
+        page_size: NonZeroUsize,
+        label_page_size: NonZeroUsize,
+    ) -> GetIssuesQuery {
         GetIssuesQuery {
             repo_id,
             cursor,
             page_size,
+            label_page_size,
             prefix: None,
         }
     }
@@ -71,7 +86,7 @@ impl GetIssuesQuery {
 }
 
 impl Query for GetIssuesQuery {
-    type Output = Page<Issue>;
+    type Output = Page<IssueWithLabels>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
         self.prefix = Some(prefix);
@@ -92,9 +107,19 @@ impl Query for GetIssuesQuery {
                         states: [OPEN],
                     ) {{
                         nodes {{
+                            id
                             number
                             title
                             url
+                            labels (first: {label_page_size}) {{
+                                nodes {{
+                                    name
+                                }}
+                                pageInfo {{
+                                    endCursor
+                                    hasNextPage
+                                }}
+                            }}
                         }}
                         pageInfo {{
                             endCursor
@@ -107,6 +132,7 @@ impl Query for GetIssuesQuery {
             repo_id_varname = self.repo_id_varname(),
             cursor_varname = self.cursor_varname(),
             page_size = self.page_size,
+            label_page_size = self.label_page_size,
         )
     }
 

--- a/crates/orgs-with-issues/src/queries/get_label_name.rs
+++ b/crates/orgs-with-issues/src/queries/get_label_name.rs
@@ -1,0 +1,62 @@
+use gqlient::{Id, Query, Singleton, Variable};
+use indoc::indoc;
+use std::fmt::{self, Write};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GetLabelName {
+    label_id: Id,
+    prefix: Option<String>,
+}
+
+impl GetLabelName {
+    pub(crate) fn new(label_id: Id) -> GetLabelName {
+        GetLabelName {
+            label_id,
+            prefix: None,
+        }
+    }
+
+    fn label_id_varname(&self) -> String {
+        match self.prefix {
+            Some(ref prefix) => format!("{prefix}_label_id"),
+            None => String::from("label_id"),
+        }
+    }
+}
+
+impl Query for GetLabelName {
+    type Output = String;
+
+    fn with_variable_prefix(mut self, prefix: String) -> Self {
+        self.prefix = Some(prefix);
+        self
+    }
+
+    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+        writeln!(
+            s,
+            indoc! {"
+            node(id: ${label_id_varname}) {{
+                ... on Label {{
+                    name
+                }}
+            }}
+        "},
+            label_id_varname = self.label_id_varname(),
+        )
+    }
+
+    fn variables(&self) -> [(String, Variable); 1] {
+        [(
+            self.label_id_varname(),
+            Variable {
+                gql_type: String::from("ID!"),
+                value: self.label_id.clone().into(),
+            },
+        )]
+    }
+
+    fn parse_response(&self, value: serde_json::Value) -> Result<Self::Output, serde_json::Error> {
+        serde_json::from_value::<Singleton<String>>(value).map(|n| n.0)
+    }
+}

--- a/crates/orgs-with-issues/src/queries/get_labels.rs
+++ b/crates/orgs-with-issues/src/queries/get_labels.rs
@@ -25,7 +25,7 @@ impl GetLabels {
 }
 
 impl Paginator for GetLabels {
-    type Item = String;
+    type Item = Id;
     type Query = GetLabelsQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetLabelsQuery {
@@ -74,7 +74,7 @@ impl GetLabelsQuery {
 }
 
 impl Query for GetLabelsQuery {
-    type Output = Page<String>;
+    type Output = Page<Id>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
         self.prefix = Some(prefix);
@@ -92,7 +92,7 @@ impl Query for GetLabelsQuery {
                         after: ${cursor_varname},
                     ) {{
                         nodes {{
-                            name
+                            id
                         }}
                         pageInfo {{
                             endCursor
@@ -128,7 +128,7 @@ impl Query for GetLabelsQuery {
     }
 
     fn parse_response(&self, value: serde_json::Value) -> Result<Self::Output, serde_json::Error> {
-        let page = serde_json::from_value::<Singleton<Page<Singleton<String>>>>(value)?.0;
+        let page = serde_json::from_value::<Singleton<Page<Singleton<Id>>>>(value)?.0;
         Ok(Page {
             items: page.items.into_iter().map(|lb| lb.0).collect(),
             end_cursor: page.end_cursor,

--- a/crates/orgs-with-issues/src/queries/get_labels.rs
+++ b/crates/orgs-with-issues/src/queries/get_labels.rs
@@ -1,0 +1,138 @@
+use gqlient::{Cursor, Id, Page, Paginator, Query, Singleton, Variable};
+use indoc::indoc;
+use std::fmt::{self, Write};
+use std::num::NonZeroUsize;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GetLabels {
+    issue_id: Id,
+    cursor: Option<Cursor>,
+    label_page_size: NonZeroUsize,
+}
+
+impl GetLabels {
+    pub(crate) fn new(
+        issue_id: Id,
+        cursor: Option<Cursor>,
+        label_page_size: NonZeroUsize,
+    ) -> GetLabels {
+        GetLabels {
+            issue_id,
+            cursor,
+            label_page_size,
+        }
+    }
+}
+
+impl Paginator for GetLabels {
+    type Item = String;
+    type Query = GetLabelsQuery;
+
+    fn for_cursor(&self, cursor: Option<&Cursor>) -> GetLabelsQuery {
+        GetLabelsQuery::new(
+            self.issue_id.clone(),
+            match cursor {
+                Some(c) => Some(c.clone()),
+                None => self.cursor.clone(),
+            },
+            self.label_page_size,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GetLabelsQuery {
+    issue_id: Id,
+    cursor: Option<Cursor>,
+    label_page_size: NonZeroUsize,
+    prefix: Option<String>,
+}
+
+impl GetLabelsQuery {
+    fn new(issue_id: Id, cursor: Option<Cursor>, label_page_size: NonZeroUsize) -> GetLabelsQuery {
+        GetLabelsQuery {
+            issue_id,
+            cursor,
+            label_page_size,
+            prefix: None,
+        }
+    }
+
+    fn issue_id_varname(&self) -> String {
+        match self.prefix {
+            Some(ref prefix) => format!("{prefix}_issue_id"),
+            None => String::from("issue_id"),
+        }
+    }
+
+    fn cursor_varname(&self) -> String {
+        match self.prefix {
+            Some(ref prefix) => format!("{prefix}_cursor"),
+            None => String::from("cursor"),
+        }
+    }
+}
+
+impl Query for GetLabelsQuery {
+    type Output = Page<String>;
+
+    fn with_variable_prefix(mut self, prefix: String) -> Self {
+        self.prefix = Some(prefix);
+        self
+    }
+
+    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+        writeln!(
+            s,
+            indoc! {"
+            node(id: ${issue_id_varname}) {{
+                ... on Issue {{
+                    labels(
+                        first: {label_page_size},
+                        after: ${cursor_varname},
+                    ) {{
+                        nodes {{
+                            name
+                        }}
+                        pageInfo {{
+                            endCursor
+                            hasNextPage
+                        }}
+                    }}
+                }}
+            }}
+        "},
+            issue_id_varname = self.issue_id_varname(),
+            cursor_varname = self.cursor_varname(),
+            label_page_size = self.label_page_size,
+        )
+    }
+
+    fn variables(&self) -> [(String, Variable); 2] {
+        [
+            (
+                self.issue_id_varname(),
+                Variable {
+                    gql_type: String::from("ID!"),
+                    value: self.issue_id.clone().into(),
+                },
+            ),
+            (
+                self.cursor_varname(),
+                Variable {
+                    gql_type: String::from("String"),
+                    value: self.cursor.clone().into(),
+                },
+            ),
+        ]
+    }
+
+    fn parse_response(&self, value: serde_json::Value) -> Result<Self::Output, serde_json::Error> {
+        let page = serde_json::from_value::<Singleton<Page<Singleton<String>>>>(value)?.0;
+        Ok(Page {
+            items: page.items.into_iter().map(|lb| lb.0).collect(),
+            end_cursor: page.end_cursor,
+            has_next_page: page.has_next_page,
+        })
+    }
+}

--- a/crates/orgs-with-issues/src/queries/get_owner_repos.rs
+++ b/crates/orgs-with-issues/src/queries/get_owner_repos.rs
@@ -8,11 +8,20 @@ use std::num::NonZeroUsize;
 pub(crate) struct GetOwnerRepos {
     owner: String,
     page_size: NonZeroUsize,
+    label_page_size: NonZeroUsize,
 }
 
 impl GetOwnerRepos {
-    pub(crate) fn new(owner: String, page_size: NonZeroUsize) -> GetOwnerRepos {
-        GetOwnerRepos { owner, page_size }
+    pub(crate) fn new(
+        owner: String,
+        page_size: NonZeroUsize,
+        label_page_size: NonZeroUsize,
+    ) -> GetOwnerRepos {
+        GetOwnerRepos {
+            owner,
+            page_size,
+            label_page_size,
+        }
     }
 }
 
@@ -21,7 +30,12 @@ impl Paginator for GetOwnerRepos {
     type Query = GetOwnerReposQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetOwnerReposQuery {
-        GetOwnerReposQuery::new(self.owner.clone(), cursor.cloned(), self.page_size)
+        GetOwnerReposQuery::new(
+            self.owner.clone(),
+            cursor.cloned(),
+            self.page_size,
+            self.label_page_size,
+        )
     }
 }
 
@@ -30,15 +44,22 @@ pub(crate) struct GetOwnerReposQuery {
     owner: String,
     cursor: Option<Cursor>,
     page_size: NonZeroUsize,
+    label_page_size: NonZeroUsize,
     prefix: Option<String>,
 }
 
 impl GetOwnerReposQuery {
-    fn new(owner: String, cursor: Option<Cursor>, page_size: NonZeroUsize) -> GetOwnerReposQuery {
+    fn new(
+        owner: String,
+        cursor: Option<Cursor>,
+        page_size: NonZeroUsize,
+        label_page_size: NonZeroUsize,
+    ) -> GetOwnerReposQuery {
         GetOwnerReposQuery {
             owner,
             cursor,
             page_size,
+            label_page_size,
             prefix: None,
         }
     }
@@ -89,9 +110,19 @@ impl Query for GetOwnerReposQuery {
                             states: [OPEN],
                         ) {{
                             nodes {{
+                                id
                                 number
                                 title
                                 url
+                                labels (first: {label_page_size}) {{
+                                    nodes {{
+                                        name
+                                    }}
+                                    pageInfo {{
+                                        endCursor
+                                        hasNextPage
+                                    }}
+                                }}
                             }}
                             pageInfo {{
                                 endCursor
@@ -109,6 +140,7 @@ impl Query for GetOwnerReposQuery {
             owner_varname = self.owner_varname(),
             cursor_varname = self.cursor_varname(),
             page_size = self.page_size,
+            label_page_size = self.label_page_size,
         )
     }
 

--- a/crates/orgs-with-issues/src/queries/get_owner_repos.rs
+++ b/crates/orgs-with-issues/src/queries/get_owner_repos.rs
@@ -116,7 +116,7 @@ impl Query for GetOwnerReposQuery {
                                 url
                                 labels (first: {label_page_size}) {{
                                     nodes {{
-                                        name
+                                        id
                                     }}
                                     pageInfo {{
                                         endCursor

--- a/crates/orgs-with-issues/src/queries/mod.rs
+++ b/crates/orgs-with-issues/src/queries/mod.rs
@@ -1,4 +1,6 @@
 mod get_issues;
+mod get_labels;
 mod get_owner_repos;
 pub(crate) use self::get_issues::GetIssues;
+pub(crate) use self::get_labels::GetLabels;
 pub(crate) use self::get_owner_repos::GetOwnerRepos;

--- a/crates/orgs-with-issues/src/queries/mod.rs
+++ b/crates/orgs-with-issues/src/queries/mod.rs
@@ -1,6 +1,8 @@
 mod get_issues;
+mod get_label_name;
 mod get_labels;
 mod get_owner_repos;
 pub(crate) use self::get_issues::GetIssues;
+pub(crate) use self::get_label_name::GetLabelName;
 pub(crate) use self::get_labels::GetLabels;
 pub(crate) use self::get_owner_repos::GetOwnerRepos;


### PR DESCRIPTION
Then do a separate batched request for the label names.
    
Unfortunately, this more than triples the runtime.

---

Offshoot of #19.

This is an historical PR kept around in case a similar strategy is needed later for something else.