### PR TITLE
Rename `Query` to `QuerySelection` etc.

### DIFF
--- a/crates/orgs-then-issues/src/queries/get_issues.rs
+++ b/crates/orgs-then-issues/src/queries/get_issues.rs
@@ -1,5 +1,5 @@
 use crate::types::{IssueWithLabels, RepoWithIssues};
-use gqlient::{Cursor, Id, Page, Paginator, Query, Variable};
+use gqlient::{Cursor, Id, Page, Paginator, QuerySelection, Variable};
 use indoc::indoc;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
@@ -27,7 +27,7 @@ impl GetIssues {
 
 impl Paginator for GetIssues {
     type Item = IssueWithLabels;
-    type Query = GetIssuesQuery;
+    type Selection = GetIssuesQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetIssuesQuery {
         GetIssuesQuery::new(
@@ -79,7 +79,7 @@ impl GetIssuesQuery {
     }
 }
 
-impl Query for GetIssuesQuery {
+impl QuerySelection for GetIssuesQuery {
     type Output = Page<IssueWithLabels>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
@@ -87,7 +87,7 @@ impl Query for GetIssuesQuery {
         self
     }
 
-    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+    fn write_selection<W: Write>(&self, mut s: W) -> fmt::Result {
         write!(
             s,
             indoc! {"

--- a/crates/orgs-then-issues/src/queries/get_labels.rs
+++ b/crates/orgs-then-issues/src/queries/get_labels.rs
@@ -1,4 +1,4 @@
-use gqlient::{Cursor, Id, Page, Paginator, Query, Singleton, Variable};
+use gqlient::{Cursor, Id, Page, Paginator, QuerySelection, Singleton, Variable};
 use indoc::indoc;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
@@ -26,7 +26,7 @@ impl GetLabels {
 
 impl Paginator for GetLabels {
     type Item = String;
-    type Query = GetLabelsQuery;
+    type Selection = GetLabelsQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetLabelsQuery {
         GetLabelsQuery::new(
@@ -73,7 +73,7 @@ impl GetLabelsQuery {
     }
 }
 
-impl Query for GetLabelsQuery {
+impl QuerySelection for GetLabelsQuery {
     type Output = Page<String>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
@@ -81,7 +81,7 @@ impl Query for GetLabelsQuery {
         self
     }
 
-    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+    fn write_selection<W: Write>(&self, mut s: W) -> fmt::Result {
         write!(
             s,
             indoc! {"

--- a/crates/orgs-then-issues/src/queries/get_owner_repos.rs
+++ b/crates/orgs-then-issues/src/queries/get_owner_repos.rs
@@ -1,5 +1,5 @@
 use crate::types::Repository;
-use gqlient::{Cursor, Page, Paginator, Query, Singleton, Variable};
+use gqlient::{Cursor, Page, Paginator, QuerySelection, Singleton, Variable};
 use indoc::indoc;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
@@ -18,7 +18,7 @@ impl GetOwnerRepos {
 
 impl Paginator for GetOwnerRepos {
     type Item = Repository;
-    type Query = GetOwnerReposQuery;
+    type Selection = GetOwnerReposQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetOwnerReposQuery {
         GetOwnerReposQuery::new(self.owner.clone(), cursor.cloned(), self.page_size)
@@ -58,7 +58,7 @@ impl GetOwnerReposQuery {
     }
 }
 
-impl Query for GetOwnerReposQuery {
+impl QuerySelection for GetOwnerReposQuery {
     type Output = Page<Repository>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
@@ -66,7 +66,7 @@ impl Query for GetOwnerReposQuery {
         self
     }
 
-    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+    fn write_selection<W: Write>(&self, mut s: W) -> fmt::Result {
         write!(
             s,
             indoc! {"

--- a/crates/orgs-with-issues/src/queries/get_issues.rs
+++ b/crates/orgs-with-issues/src/queries/get_issues.rs
@@ -1,5 +1,5 @@
 use crate::types::{IssueWithLabels, RepoWithIssues};
-use gqlient::{Cursor, Id, Page, Paginator, Query, Variable};
+use gqlient::{Cursor, Id, Page, Paginator, QuerySelection, Variable};
 use indoc::indoc;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
@@ -30,7 +30,7 @@ impl GetIssues {
 
 impl Paginator for GetIssues {
     type Item = IssueWithLabels;
-    type Query = GetIssuesQuery;
+    type Selection = GetIssuesQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetIssuesQuery {
         GetIssuesQuery::new(
@@ -85,7 +85,7 @@ impl GetIssuesQuery {
     }
 }
 
-impl Query for GetIssuesQuery {
+impl QuerySelection for GetIssuesQuery {
     type Output = Page<IssueWithLabels>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
@@ -93,7 +93,7 @@ impl Query for GetIssuesQuery {
         self
     }
 
-    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+    fn write_selection<W: Write>(&self, mut s: W) -> fmt::Result {
         write!(
             s,
             indoc! {"

--- a/crates/orgs-with-issues/src/queries/get_labels.rs
+++ b/crates/orgs-with-issues/src/queries/get_labels.rs
@@ -1,4 +1,4 @@
-use gqlient::{Cursor, Id, Page, Paginator, Query, Singleton, Variable};
+use gqlient::{Cursor, Id, Page, Paginator, QuerySelection, Singleton, Variable};
 use indoc::indoc;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
@@ -26,7 +26,7 @@ impl GetLabels {
 
 impl Paginator for GetLabels {
     type Item = String;
-    type Query = GetLabelsQuery;
+    type Selection = GetLabelsQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetLabelsQuery {
         GetLabelsQuery::new(
@@ -73,7 +73,7 @@ impl GetLabelsQuery {
     }
 }
 
-impl Query for GetLabelsQuery {
+impl QuerySelection for GetLabelsQuery {
     type Output = Page<String>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
@@ -81,7 +81,7 @@ impl Query for GetLabelsQuery {
         self
     }
 
-    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+    fn write_selection<W: Write>(&self, mut s: W) -> fmt::Result {
         write!(
             s,
             indoc! {"

--- a/crates/orgs-with-issues/src/queries/get_owner_repos.rs
+++ b/crates/orgs-with-issues/src/queries/get_owner_repos.rs
@@ -1,5 +1,5 @@
 use crate::types::RepoWithIssues;
-use gqlient::{Cursor, Page, Paginator, Query, Singleton, Variable};
+use gqlient::{Cursor, Page, Paginator, QuerySelection, Singleton, Variable};
 use indoc::indoc;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
@@ -27,7 +27,7 @@ impl GetOwnerRepos {
 
 impl Paginator for GetOwnerRepos {
     type Item = RepoWithIssues;
-    type Query = GetOwnerReposQuery;
+    type Selection = GetOwnerReposQuery;
 
     fn for_cursor(&self, cursor: Option<&Cursor>) -> GetOwnerReposQuery {
         GetOwnerReposQuery::new(
@@ -79,7 +79,7 @@ impl GetOwnerReposQuery {
     }
 }
 
-impl Query for GetOwnerReposQuery {
+impl QuerySelection for GetOwnerReposQuery {
     type Output = Page<RepoWithIssues>;
 
     fn with_variable_prefix(mut self, prefix: String) -> Self {
@@ -87,7 +87,7 @@ impl Query for GetOwnerReposQuery {
         self
     }
 
-    fn write_graphql<W: Write>(&self, mut s: W) -> fmt::Result {
+    fn write_selection<W: Write>(&self, mut s: W) -> fmt::Result {
         write!(
             s,
             indoc! {"


### PR DESCRIPTION
Closes #47.